### PR TITLE
add dockerless build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ jobs:
     - stage: check examples
       script:
         - mkdir -p output
-        - for f in *.conf; do ./builder.sh build $f; done
+        - for f in *.conf; do ./builder.sh build-docker-image $f && ./builder.sh build $f; done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for lede-dockerbuilder
 
+## v2.0 [2019-07-28]
+
+* add new option `--dockerless` to allow dockerless operation using buildah
+  and podman. 
+* `build` option does now longer implicitly builds the docker image. Must now
+  explicitly call `build-docker-image` before building an OpenWrt image.
+* minor optimizations in Dockerfile
+
 ## v1.5 [2019-07-06]
 
 * examples upgraded to use 18.06.4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dockerized OpenWrt image builder
+# Containerized OpenWrt image builder
 
 [![Build Status](https://travis-ci.org/jandelgado/lede-dockerbuilder.svg?branch=master)](https://travis-ci.org/jandelgado/lede-dockerbuilder)
 
@@ -9,6 +9,7 @@
 * [Why](#why)
 * [How](#how)
     * [Usage](#usage)
+        * [Dockerless operation](#dockerless-operation)
     * [Configuration file](#configuration-file)
     * [File system overlay](#file-system-overlay)
     * [Example directory structure](#example-directory-structure)
@@ -23,11 +24,11 @@
 
 ## What
 
-Easily and quickly build OpenWrt custom images (e.g. for your embedded device our Raspberry PI) 
-using a self-contained docker container and the
+Easily and quickly build OpenWrt custom images (e.g. for your embedded device
+our Raspberry PI) using a self-contained docker container and the
 [OpenWrt](https://wiki.openwrt.org/doc/howto/obtain.firmware.generate) image
-builder. On the builder host, Docker is the only requirement. Supports latest
-OpenWrt release (18.06.x).
+builder. On the builder host, Docker or podman/buildah (for dockerless
+operation) is the only requirement. Supports latest OpenWrt release (18.06.4).
 
 ### Note
 
@@ -47,37 +48,44 @@ for a docker images to compile OpenWrt completely from source.
 ```
 $ git clone https://github.com/jandelgado/lede-dockerbuilder.git
 $ cd lede-dockerbuilder
+$ ./builder.sh build-docker-image example-nexx-wt3020.conf
 $ ./builder.sh build example-nexx-wt3020.conf
 ```
-Your custom images can now be found in the `output` diretory.
 
-The `build` command will first build the docker image containing the actual image
-builder. The resulting docker image is per default tagged with
-`openwrt-imagebuilder:<Release>-<Target>-<Subtarget>`.  Afterwards a container,
-which builds the actual OpenWrt image, is run. The final OpenWrt image will be
-available in the `output/` directory.
+The `build-docker-image` command will first build the docker image containing
+the actual image builder. The resulting docker image is per default tagged with
+`openwrt-imagebuilder:<Release>-<Target>-<Subtarget>`.  The `build` command
+will afterwards run a container, which builds the actual OpenWrt image. The
+final OpenWrt image will be available in the `output/` directory.
 
 ### Usage
+
 ```
-Dockerized LEDE/OpenWrt image builder.
+Dockerized LEDE/OpenWRT image builder.
 
 Usage: ./builder.sh COMMAND CONFIGFILE [OPTIONS] 
   COMMAND is one of:
-    build-docker-image- just build the docker image
-    build             - build docker image, then start container and build the LEDE/OpenWrt image
+    build-docker-image- build the docker image (run once first)
+    build             - start container and build the LEDE/OpenWRT image
     shell             - start shell in docker container
   CONFIGFILE          - configuraton file to use
 
   OPTIONS:
-  -o OUTPUT_DIR       - output directory 
-  -f ROOTFS_OVERLAY   - rootfs-overlay directory 
+  -o OUTPUT_DIR       - output directory (default /home/paco/src/lede-dockerbuilder/output)
+  -f ROOTFS_OVERLAY   - rootfs-overlay directory (default /home/paco/src/lede-dockerbuilder/rootfs-overlay)
   --skip-sudo         - call docker directly, without sudo
+  --dockerless        - use podman and buildah instead of docker daemon
 
   command line options -o, -f override config file settings.
 
 Example:
   ./builder.sh build example.cfg -o output -f myrootfs
 ```
+
+#### Dockerless operation
+
+When called with `--dockerless` option, lede-dockerbuilder will use buildah and 
+podman to build and run the container.
 
 ### Configuration file
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,21 +1,23 @@
 FROM gliderlabs/alpine:3.9
 LABEL maintainer "Jan Delgado <jdelgado@gmx.net>"
 
-
-RUN  apk add --update asciidoc bash bc binutils bzip2 cdrkit coreutils diffutils findutils flex g++ gawk gcc gettext git grep intltool libxslt linux-headers make ncurses-dev patch perl python2-dev tar unzip  util-linux wget zlib-dev xz\
+RUN  apk add --update asciidoc bash bc binutils bzip2 cdrkit coreutils\
+                      diffutils findutils flex g++ gawk gcc gettext git grep\
+                      intltool libxslt linux-headers make ncurses-dev patch\
+                      perl python2-dev tar unzip  util-linux wget zlib-dev xz\
+     && apk add --update gosu --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing \
      && rm -rf /var/cache/apk/*
 
-ADD https://github.com/tianon/gosu/releases/download/1.11/gosu-amd64 /usr/local/bin/gosu
 ADD etc/entrypoint.sh /usr/local/bin/
-RUN chmod 755 /usr/local/bin/entrypoint.sh /usr/local/bin/gosu
+RUN chmod 755 /usr/local/bin/entrypoint.sh 
 
 # install the image builder. use tmpfile so that tar's compression
 # autodetection works.
 ARG BUILDER_URL
-RUN mkdir -p /lede/imagebuilder && \
-    wget  --progress=bar:force:noscroll $BUILDER_URL -O /tmp/imagebuilder && \
-      tar xf /tmp/imagebuilder --strip-components=1 -C /lede/imagebuilder &&\
-      rm -f /tmp/imagebuilder
+RUN    mkdir -p /lede/imagebuilder\
+    && wget  --progress=bar:force:noscroll $BUILDER_URL -O /tmp/imagebuilder\
+    && tar xf /tmp/imagebuilder --strip-components=1 -C /lede/imagebuilder\
+    && rm -f /tmp/imagebuilder
 
 
 WORKDIR "/lede/imagebuilder"

--- a/docker/etc/entrypoint.sh
+++ b/docker/etc/entrypoint.sh
@@ -1,18 +1,18 @@
 #!/bin/sh
 
-chown -R $GOSU_USER /lede
+chown -R "$GOSU_UID:$GOSU_GID" /lede
 
-# If GOSU_USER environment variable set to something other than 0:0 (root:root),
+# If GOSU_UID:GOSU_GID environment variable set to something other than 0:0 (root:root),
 # become user:group set within and exec command passed in args
-if [ "$GOSU_USER" != "0:0" ]; then
+if [ "$GOSU_UID:$GOSU_GID" != "0:0" ]; then
     # make sure a valid user exists in /etc/passwd
-    if grep "^builder:" /etc/passwd; then
-      sed -i "/^builder:/d" /etc/passwd
-    fi
-    echo "builder:x:$GOSU_USER:LEDE builder:/lede:/bin/bash" >> /etc/passwd
-    exec /usr/local/bin/gosu $GOSU_USER "$@"
+    sed -i "/^builder:/d" /etc/passwd || true
+    echo "builder:x:$GOSU_UID:$GOSU_GID:LEDE builder:/lede:/bin/bash" >> /etc/passwd
+    sed -i "/^builder:/d" /etc/group || true
+    echo "builder:x:$GOSU_GID" >> /etc/group
+    exec gosu "$GOSU_UID:$GOSU_GID" "$@"
 fi
 
-# If GOSU_USER was 0:0 exec command passed in args without gosu (assume already root)
+# If GOSU_UID:GOSU_GID was 0:0 exec command passed in args without gosu (assume already root)
 exec "$@"
 


### PR DESCRIPTION
* add new option `--dockerless` to allow dockerless operation using buildah
  and podman. 
* `build` option does now longer implicitly builds the docker image. Must now
  explicitly call `build-docker-image` before building an OpenWrt image.
* minor optimizations in Dockerfile

