### PR TITLE
add new `--docker-opts OPTS` option which is passed to docker-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for lede-dockerbuilder
 
+## v2.4 [2020-05-25]
+
+* new option `--docker-opts OPTS` to pass additional docker options to docker-run
+* examples upgraded to use OpenWrt 19.07.3
+* new Raspberry Pi 4 example
+
 ## v2.3 [2020-01-26]
 
 * changed: when using podman, run as root in container

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ final OpenWrt image will be available in the `output/` directory.
 ```
 Dockerized LEDE/OpenWRT image builder.
 
-Usage: ./builder.sh COMMAND CONFIGFILE [OPTIONS] 
+Usage: ./builder.sh COMMAND CONFIGFILE [OPTIONS]
   COMMAND is one of:
     build-docker-image- build the docker image (run once first)
     build             - start container and build the LEDE/OpenWRT image
@@ -72,6 +72,8 @@ Usage: ./builder.sh COMMAND CONFIGFILE [OPTIONS]
 
   OPTIONS:
   -o OUTPUT_DIR       - output directory (default /home/paco/src/lede-dockerbuilder/output)
+  --docker-opts OPTS  - additional options to pass to docker run
+                        (can occur multiple times)
   -f ROOTFS_OVERLAY   - rootfs-overlay directory (default /home/paco/src/lede-dockerbuilder/rootfs-overlay)
   --skip-sudo         - call docker directly, without sudo
   --dockerless        - use podman and buildah instead of docker daemon
@@ -79,7 +81,11 @@ Usage: ./builder.sh COMMAND CONFIGFILE [OPTIONS]
   command line options -o, -f override config file settings.
 
 Example:
+  # standard invocation
   ./builder.sh build example.cfg -o output -f myrootfs
+
+  # mount downloads to host directory
+  ./builder.sh build example-nexx-wt3020.conf --docker-opts "-v=$(pwd)/dl:/lede/imagebuilder/dl:z"
 ```
 
 #### Dockerless operation


### PR DESCRIPTION
Allows to pass additional options to docker-run, e.g. to mount the download directory to a host directory:
```
 ./builder.sh build example-nexx-wt3020.conf --docker-opts "-v=$(pwd)/dl:/lede/imagebuilder/dl:z"
```