### PR TITLE
support nerdctl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,4 +35,4 @@ jobs:
           time ./builder.sh build-docker-image \
                   example-${{ matrix.example }}.conf ${{ matrix.option }}  ${{ matrix.sudo }} &&\
           time ./builder.sh build \
-                  example-${{ matrix.example }}.conf ${{ matrix.option }} ${{ matix.sudo }}
+                  example-${{ matrix.example }}.conf ${{ matrix.option }} ${{ matrix.sudo }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,24 +20,19 @@ jobs:
     strategy:
       matrix:
         example: ["x86_64", "rpi4", "ginet-gl-mt300n-v2", "nexx-wt3020", "rpi2", "wrt1043nd"]
-        option: ["--nerdctl", "--docker", "--podman"]
+        option: ["--docker", "--podman"]
+        sudo: ["", "--sudo"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: install podman
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install podman curl
-          curl -qL "https://github.com/containerd/nerdctl/releases/download/v0.17.1/nerdctl-0.17.1-linux-amd64.tar.gz" -o nerdctl.tgz
-          mkdir -p $HOME/.local/bin
-          tar xvzf nerdctl.tgz -C $HOME/.local/bin
+          sudo apt-get -y install podman
       - name: test build example
         run: |
-          echo $PATH
-          PATH="$PATH:$HOME/.local/bin"
-          containerd-rootless-setuptool.sh install
           mkdir -p output
           time ./builder.sh build-docker-image \
-                  example-${{ matrix.example }}.conf ${{ matrix.option }}  &&\
+                  example-${{ matrix.example }}.conf ${{ matrix.option }}  ${{ matrix.sudo }} &&\
           time ./builder.sh build \
-                  example-${{ matrix.example }}.conf ${{ matrix.option }}
+                  example-${{ matrix.example }}.conf ${{ matrix.option }} ${{ matix.sudo }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,22 @@ jobs:
     strategy:
       matrix:
         example: ["x86_64", "rpi4", "ginet-gl-mt300n-v2", "nexx-wt3020", "rpi2", "wrt1043nd"]
-        option: ["--skip-sudo", "--dockerless"]
+        option: ["--nerdctl", "--docker", "--podman"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: install podman
         run: |
           sudo apt-get -y update
-          sudo apt-get -y install podman
+          sudo apt-get -y install podman curl
+          curl -qL "https://github.com/containerd/nerdctl/releases/download/v0.17.1/nerdctl-0.17.1-linux-amd64.tar.gz" -o nerdctl.tgz
+          mkdir -p $HOME/.local/bin
+          tar xvzf nerdctl.tgz -C $HOME/.local/bin
       - name: test build example
         run: |
+          echo $PATH
+          PATH="$PATH:$HOME/.local/bin"
+          containerd-rootless-setuptool.sh install
           mkdir -p output
           time ./builder.sh build-docker-image \
                   example-${{ matrix.example }}.conf ${{ matrix.option }}  &&\

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for lede-dockerbuilder
 
+## v2.12 [2022-03-20]
+
+* new option: `--nerdctl` to build&run container with nerdctl 
+* change: `--skip-sudo` removed, is now the default. Use `--sudo` to enable 
+          sudo
+
 ## v2.11 [2022-03-16]
 
 * bump to OpenWrt 21.02.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # Changelog for lede-dockerbuilder
 
-## v2.12 [2022-03-20]
+## v3.0 [2022-03-20]
 
-* new option: `--nerdctl` to build&run container with nerdctl 
-* change: `--skip-sudo` removed, is now the default. Use `--sudo` to enable 
-          sudo
+* add experimental support for nerdctl with the new `--nerdctl` option
+* `--dockerless` option removed, use `--podman` or `--nerdctl` instead.
+  Docker is still the default
+* `--skip-sudo` removed, is now the default. Use `--sudo` to run commands with
+  sudo
+* use ubuntu LTS as base image
 
 ## v2.11 [2022-03-16]
 

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2017-2022 Jan Delgado
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@
 <!-- vim-markdown-toc GFM -->
 
 * [What](#what)
-    * [Note](#note)
+	* [Note](#note)
 * [Why](#why)
 * [How](#how)
-    * [Usage](#usage)
-        * [Dockerless operation](#dockerless-operation)
-    * [Configuration file](#configuration-file)
-    * [File system overlay](#file-system-overlay)
-    * [Example directory structure](#example-directory-structure)
-        * [Debugging](#debugging)
+	* [Usage](#usage)
+		* [Dockerless operation](#dockerless-operation)
+	* [Configuration file](#configuration-file)
+	* [File system overlay](#file-system-overlay)
+	* [Example directory structure](#example-directory-structure)
+		* [Debugging](#debugging)
 * [Examples](#examples)
-    * [Building a x86_64 image and running it in qemu](#building-a-x86_64-image-and-running-it-in-qemu)
+	* [Building a x86_64 image and running it in qemu](#building-a-x86_64-image-and-running-it-in-qemu)
 * [Building an OpenWrt snapshot release](#building-an-openwrt-snapshot-release)
 * [Author](#author)
 * [License](#license)
@@ -67,18 +67,21 @@ Dockerized LEDE/OpenWRT image builder.
 Usage: ./builder.sh COMMAND CONFIGFILE [OPTIONS]
   COMMAND is one of:
     build-docker-image - build the docker image (run once first)
-    profiles  - start container and show avail profiles for current configuration
-    build     - start container and build the LEDE/OpenWRT image
-    shell     - start shell in docker container
-  CONFIGFILE  - configuraton file to use
+    profiles           - start container and show avail profiles for
+                         current configuration
+    build              - start container and build the LEDE/OpenWRT image
+    shell              - start shell in docker container
+  CONFIGFILE           - configuraton file to use
 
   OPTIONS:
-  -o OUTPUT_DIR       - output directory (default /home/paco/src/lede-dockerbuilder/output)
-  --docker-opts OPTS  - additional options to pass to docker run
-                        (can occur multiple times)
-  -f ROOTFS_OVERLAY   - rootfs-overlay directory (default /home/paco/src/lede-dockerbuilder/rootfs-overlay)
-  --skip-sudo         - call docker directly, without sudo
-  --dockerless        - use podman and buildah instead of docker daemon
+  -o OUTPUT_DIR        - output directory (default /home/paco/src/lede-dockerbuilder/output)
+  --docker-opts OPTS   - additional options to pass to docker run
+                         (can occur multiple times)
+  -f ROOTFS_OVERLAY    - rootfs-overlay directory (default /home/paco/src/lede-dockerbuilder/rootfs-overlay)
+  --sudo               - call container tool with sudo
+  --podman             - use buildah and podman to build and run container
+  --nerdctl            - use nerdctl to build and run container
+  --docker             - use docker to build and run container (default)
 
   command line options -o, -f override config file settings.
 
@@ -90,16 +93,20 @@ Example:
   ./builder.sh build example.conf -o output -f myrootfs
 
   # show available profiles
-  ./builder.sh profiles example.conf 
+  ./builder.sh profiles example.conf
 
   # mount downloads to host directory during build
   ./builder.sh build example-nexx-wt3020.conf --docker-opts "-v=$(pwd)/dl:/lede/imagebuilder/dl:z"
 ```
 
-#### Dockerless operation
+#### Container runtime
 
-When called with `--dockerless` option, lede-dockerbuilder will use buildah and 
-podman to build and run the container.
+* By default docker will be used to build and run the container.
+* When called with `--podman` option, lede-dockerbuilder will use buildah and
+  podman to build and run the container.
+* When called with `--nerdctl` option, lede-dockerbuilder will use nerdctl to
+  build and run the container.
+* Use the `--sudo` option to run the container command with sudo.
 
 ### Configuration file
 
@@ -158,7 +165,11 @@ LEDE_TARGET=ramips
 LEDE_SUBTARGET=mt7620
 
 # list packages to include in LEDE image. prepend packages to deinstall with "-".
-LEDE_PACKAGES="ksmbd-server ksmbd-utils vsftpd lsblk iwinfo tcpdump block-mount\
+# 
+# include all packages to build a mobile NAS supporting disk encryption:
+# ksmbd (samba4 is too large now for the WT3020's 8MB), cryptsetup.
+# see https://github.com/namjaejeon/ksmbd-tools for ksmbd info.
+LEDE_PACKAGES="ksmbd-server ksmbd-utils lsblk iwinfo tcpdump block-mount\
     kmod-usb-storage-uas kmod-scsi-core kmod-fs-ext4 ntfs-3g\
     kmod-nls-cp437 kmod-nls-iso8859-1 cryptsetup kmod-crypto-xts\
     kmod-mt76 kmod-usb2 kmod-usb-ohci kmod-usb-core kmod-dm kmod-crypto-ecb\
@@ -166,6 +177,9 @@ LEDE_PACKAGES="ksmbd-server ksmbd-utils vsftpd lsblk iwinfo tcpdump block-mount\
     kmod-crypto-user\
     -ppp -kmod-ppp -kmod-pppoe -kmod-pppox -ppp-mod-pppoe\
     -ip6tables -odhcp6c -kmod-ipv6 -kmod-ip6tables -odhcpd-ipv6only"
+
+# optionally override OUTPUT_DIR and ROOTFS_OVERLAY directory location here
+
 ```
 
 ### File system overlay
@@ -298,7 +312,7 @@ the raspi 4, which is (as of may 2020) only available on the snapshots branch.
 
 ## Author
 
-Jan Delgado
+(C) Copyright 2017-2022 by Jan Delgado
 
 ## License
 

--- a/builder.sh
+++ b/builder.sh
@@ -84,8 +84,8 @@ function run_cmd_in_container {
     $SUDO $DOCKER_RUN\
         --rm\
 		$docker_term_opts \
-        -v "$(abspath "$ROOTFS_OVERLAY")":/lede/rootfs-overlay:z \
-        -v "$(abspath "$OUTPUT_DIR")":/lede/output:z \
+        -v "$(abspath "$ROOTFS_OVERLAY")":/lede/rootfs-overlay \
+        -v "$(abspath "$OUTPUT_DIR")":/lede/output \
         "${repositories_volume[@]}" \
         ${DOCKER_OPTS[@]} \
         --rm "$IMAGE_TAG" "$@"
@@ -160,8 +160,6 @@ while [[ $# -ge 1 ]]; do
             DOCKER_OPTS+=("$2"); shift 
             ;;
         --docker)
-            DOCKER_BUILD="docker build"
-            DOCKER_RUN="docker run -e GOSU_UID=$(id -ur) -e GOSU_GID=$(id -g)"
             ;;
         --nerdctl)
             DOCKER_BUILD="nerdctl build"

--- a/builder.sh
+++ b/builder.sh
@@ -117,6 +117,10 @@ function fail {
     exit 1
 }
 
+function warn {
+    echo "WARNING: $*" >&2
+}
+
 if [ $# -lt 2 ]; then
     usage "$0"
     exit 1
@@ -169,6 +173,13 @@ while [[ $# -ge 1 ]]; do
             DOCKER_BUILD="buildah bud --layers=true"
             DOCKER_RUN="podman run" 
             ;;
+        --dockerless)
+            fail "option --dockerless removed. Use --podman or --nerdctl instead"
+            ;;
+        --skip-sudo)
+            warn "option --skip-sudo removed (is now the default). Use --sudo to enable sudo"
+            ;;
+
         *)
             fail "invalid option: $key";;
     esac

--- a/builder.sh
+++ b/builder.sh
@@ -37,7 +37,7 @@ Usage: $1 COMMAND CONFIGFILE [OPTIONS]
   --sudo               - call container tool with sudo
   --podman             - use buildah and podman to build and run container
   --nerdctl            - use nerdctl to build and run container
-  --docker             - use docker to build and run container
+  --docker             - use docker to build and run container (default)
 
   command line options -o, -f override config file settings.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,13 +1,11 @@
-FROM alpine:3.13.1
+FROM ubuntu:18.04
 LABEL maintainer "Jan Delgado <jdelgado@gmx.net>"
 
-RUN  apk add --update asciidoc bash bc binutils bzip2 cdrkit coreutils\
-                      diffutils findutils flex g++ gawk gcc gettext git grep\
-                      intltool libxslt linux-headers make ncurses-dev patch\
-                      perl python2-dev tar unzip  util-linux wget zlib-dev xz\
-                      python3 rsync\
-                      su-exec\
-     && rm -rf /var/cache/apk/*
+RUN    apt-get update\
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential\
+         libncurses5-dev libncursesw5-dev zlib1g-dev gawk git gettext libssl-dev\
+         xsltproc rsync wget unzip python3 \
+    && rm -rf /var/lib/apt/lists/*
 
 ADD etc/entrypoint.sh /usr/local/bin/
 RUN chmod 755 /usr/local/bin/entrypoint.sh 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer "Jan Delgado <jdelgado@gmx.net>"
 RUN    apt-get update\
     && DEBIAN_FRONTEND=noninteractive apt-get install -y build-essential\
          libncurses5-dev libncursesw5-dev zlib1g-dev gawk git gettext libssl-dev\
-         xsltproc rsync wget unzip python3 \
+         xsltproc rsync wget unzip python3\
     && rm -rf /var/lib/apt/lists/*
 
 ADD etc/entrypoint.sh /usr/local/bin/
@@ -17,8 +17,7 @@ ADD $BUILDER_URL /tmp/imagebuilder
 
 RUN    mkdir -p /lede/imagebuilder\
     && tar xf /tmp/imagebuilder --strip-components=1 -C /lede/imagebuilder\
-    && rm -f /tmp/imagebuilder
-
+    && rm -f /tmp/imagebuilder 
 
 WORKDIR "/lede/imagebuilder"
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/docker/etc/entrypoint.sh
+++ b/docker/etc/entrypoint.sh
@@ -7,16 +7,13 @@ set -e
 if [ "$GOSU_UID:$GOSU_GID" != "0:0" ] && [ "$GOSU_UID:$GOSU_GID" != ":" ]; then
     export HOME="/lede"
 
-    chown "$GOSU_UID:$GOSU_GID" /lede
-    chown "$GOSU_UID:$GOSU_GID" /lede/*
 
-    # only needed when run with docker
-    if [ -f /.dockerenv ]; then
-        echo hello
-#        chown -R "$GOSU_UID:$GOSU_GID" /lede
-    fi
+
     groupadd -f -g "$GOSU_GID" builder
     useradd -u "$GOSU_UID" -g "$GOSU_GID" -s /bin/bash -d "/lede" builder || :
+
+    # make sure user has write permissions 
+    su builder -c "touch /lede/.writetest > /dev/null 2>&1" || ( echo "fix permissions..."; chown -R "$GOSU_UID:$GOSU_GID" /lede/imagebuilder )
     exec chroot --userspec "$GOSU_UID:$GOSU_GID" --skip-chdir / "$@"
 fi
 

--- a/docker/etc/entrypoint.sh
+++ b/docker/etc/entrypoint.sh
@@ -1,22 +1,26 @@
 #!/bin/sh
+set -e
 
-# only needed in docker, not rootless podman.
-if [ -f /.dockerenv ]; then
-    # this is very, very slow inside a docker container.
-    chown -R "$GOSU_UID:$GOSU_GID" /lede
-fi
 
 # If GOSU_UID:GOSU_GID environment variable set to something other than 0:0 (root:root),
 # become user:group set within and exec command passed in args
-if [ "$GOSU_UID:$GOSU_GID" != "0:0" ]; then
-    # make sure a valid user exists in /etc/passwd
-    sed -i "/^builder:/d" /etc/passwd || true
-    echo "builder:x:$GOSU_UID:$GOSU_GID:LEDE builder:/lede:/bin/bash" >> /etc/passwd
-    sed -i "/^builder:/d" /etc/group || true
-    echo "builder:x:$GOSU_GID" >> /etc/group
-    exec su-exec "$GOSU_UID:$GOSU_GID" "$@"
+if [ "$GOSU_UID:$GOSU_GID" != "0:0" ] && [ "$GOSU_UID:$GOSU_GID" != ":" ]; then
+    export HOME="/lede"
+
+    chown "$GOSU_UID:$GOSU_GID" /lede
+    chown "$GOSU_UID:$GOSU_GID" /lede/*
+
+    # only needed when run with docker
+    if [ -f /.dockerenv ]; then
+        echo hello
+#        chown -R "$GOSU_UID:$GOSU_GID" /lede
+    fi
+    groupadd -f -g "$GOSU_GID" builder
+    useradd -u "$GOSU_UID" -g "$GOSU_GID" -s /bin/bash -d "/lede" builder || :
+    exec chroot --userspec "$GOSU_UID:$GOSU_GID" --skip-chdir / "$@"
 fi
 
-# If GOSU_UID:GOSU_GID was 0:0 exec command passed in args without gosu (assume already root)
+# If GOSU_UID:GOSU_GID was 0:0 exec command passed in args
+# without gosu (assume already root)
 exec "$@"
 


### PR DESCRIPTION
* add expermental support for nerdctl with `--nerdctl`
* `--dockerless` option removed, use `--podman` or `--nerdctl` instead. Docker is still the default
* `--skip-sudo` removed, is now the default. Use `--sudo` to run commands with `sudo`
* use ubuntu LTS as base image